### PR TITLE
Update to allow custom_fields to metadata

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -113,7 +113,21 @@ class Paystack
             "plan" => request()->plan,
             "first_name" => request()->first_name,
             "last_name" => request()->last_name,
-            "callback_url" => request()->callback_url
+            "callback_url" => request()->callback_url,
+            /*
+            * to allow use of metadata on Paystack dashboard and a means to return additional data back to redirect url
+            * form need an input field: <input type="hidden" name="metadata" value="{{ json_encode($array) }}" >
+            *array must be set up as: $array = [ 'custom_fields' => [
+            *                                                            ['display_name' => "Cart Id", "variable_name" => "cart_id", "value" => "2"],
+            *                                                            ['display_name' => "Sex", "variable_name" => "sex", "value" => "female"],
+            *                                                            .
+            *                                                            .
+            *                                                            .
+            *                                                        ]
+            *                                        
+            *                                  ]
+            */
+            'metadata' => request()->metadata 
         ];
 
         // Remove the fields which were not sent (value would be null)


### PR DESCRIPTION
A means to set additional info on Paystack dashboard and get specific return data on callback url for ease of maintence of web app database.