### PR TITLE
add metadata to form

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ A sample form will look like so:
             <input type="hidden" name="orderID" value="345">
             <input type="hidden" name="amount" value="800"> {{-- required in kobo --}}
             <input type="hidden" name="quantity" value="3">
+            <input type="hidden" name="metadata" value="{{ json_encode($array = ['key_name' => 'value',]) }}" > {{-- For other necessary things you want to add to your payload. it is optional though --}}
             <input type="hidden" name="reference" value="{{ Paystack::genTranxRef() }}"> {{-- required --}}
             <input type="hidden" name="key" value="{{ config('paystack.secretKey') }}"> {{-- required --}}
             {{ csrf_field() }} {{-- works only when using laravel 5.1, 5.2 --}}


### PR DESCRIPTION
Just found that adding the metadata input box to form would ease the stress of a developer trying to read Paystack's documentation of how to add metadata. Many developers are not too patient to go through the package source code like I did till I found it. It would be pretty helpful