### PR TITLE
Modify payment verification logic to accept external payment reference

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -197,10 +197,11 @@ class Paystack
 
     /**
      * Hit Paystack Gateway to Verify that the transaction is valid
+     * @param  $trxref
      */
-    private function verifyTransactionAtGateway()
+    private function verifyTransactionAtGateway($trxref)
     {
-        $transactionRef = request()->query('trxref');
+        $transactionRef = $trxref ?: request()->query('trxref');
 
         $relativeUrl = "/transaction/verify/{$transactionRef}";
 
@@ -209,11 +210,12 @@ class Paystack
 
     /**
      * True or false condition whether the transaction is verified
+     * @param $trxref
      * @return boolean
      */
-    public function isTransactionVerificationValid()
+    public function isTransactionVerificationValid($trxref = null)
     {
-        $this->verifyTransactionAtGateway();
+        $this->verifyTransactionAtGateway($trxref);
 
         $result = $this->getResponse()['message'];
 


### PR DESCRIPTION
Currently, this library only verifies payments made by it self on the server side. In a case where paystack inline is used to make a transaction on the client side using libraries like react, Angular, Vue. It should be possible to verify that the transaction is valid before storing in the database or carrying out further actions on the server side. With this PR, providing just a transaction reference will be enough, and the method can be used like so
`
$trxref = 'ghdjkfkj34224442';  //sample refrence
Paystack::isTransactionVerificationValid($trxref);`