### PR TITLE
Removed line that fetches secret key in transaction form

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ A sample form will look like so:
             <input type="hidden" name="quantity" value="3">
             <input type="hidden" name="metadata" value="{{ json_encode($array = ['key_name' => 'value',]) }}" > {{-- For other necessary things you want to add to your payload. it is optional though --}}
             <input type="hidden" name="reference" value="{{ Paystack::genTranxRef() }}"> {{-- required --}}
-            <input type="hidden" name="key" value="{{ config('paystack.secretKey') }}"> {{-- required --}}
             {{ csrf_field() }} {{-- works only when using laravel 5.1, 5.2 --}}
 
              <input type="hidden" name="_token" value="{{ csrf_token() }}"> {{-- employ this in place of csrf_field only in laravel 5.0 --}}


### PR DESCRIPTION
The payment still works without the line.