### PR TITLE
Created an optional parameter for getPaymentData.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@
 
 [PHP](https://php.net) 5.4+ or [HHVM](http://hhvm.com) 3.3+, and [Composer](https://getcomposer.org) are required.
 
-To get the latest version of Laravel Paystack, simply require it
-
-```bash
-composer require unicodeveloper/laravel-paystack
-```
-
-Or add the following line to the require block of your `composer.json` file.
+To get the latest version of Laravel Paystack, simply add the following line to the require block of your `composer.json` file.
 
 ```
 "unicodeveloper/laravel-paystack": "1.0.*"
@@ -26,11 +20,7 @@ Or add the following line to the require block of your `composer.json` file.
 
 You'll then need to run `composer install` or `composer update` to download it and have the autoloader updated.
 
-
-
 Once Laravel Paystack is installed, you need to register the service provider. Open up `config/app.php` and add the following to the `providers` key.
-
-> If you use **Laravel >= 5.5** you can skip this step and go to [**`configuration`**](https://github.com/unicodeveloper/laravel-paystack#configuration)
 
 * `Unicodeveloper\Paystack\PaystackServiceProvider::class`
 
@@ -126,30 +116,16 @@ Note: Make sure you have `/payment/callback` registered in Paystack Dashboard [h
 ![payment-callback](https://cloud.githubusercontent.com/assets/2946769/12746754/9bd383fc-c9a0-11e5-94f1-64433fc6a965.png)
 
 ```php
-// Laravel 5.1.17 and above
-Route::post('/pay', 'PaymentController@redirectToGateway')->name('pay'); 
-```
+Route::post('/pay', 'PaymentController@redirectToGateway')->name('pay'); // Laravel 5.1.17 and above
 
 OR
 
-```php
 Route::post('/pay', [
     'uses' => 'PaymentController@redirectToGateway',
     'as' => 'pay'
 ]);
-```
 
-```php
 Route::get('/payment/callback', 'PaymentController@handleGatewayCallback');
-```
-
-OR
-
-```php
-// Laravel 5.0
-Route::get('payment/callback', [
-    'uses' => 'PaymentController@handleGatewayCallback'
-]); 
 ```
 
 ```php
@@ -210,6 +186,15 @@ Paystack::getAuthorizationUrl()->redirectNow();
 Paystack::getPaymentData();
 
 /**
+* Alternatively, you could get payment information is the route is modified or payment needs verification 
+* after being processed from the frontend using Javascript or any other method other than the webhook/callback
+* route.
+*
+* Example: Paystack::getPaymentData(830987050); 
+*/
+Paystack::getPaymentData($transactionReferenceKey);
+
+/**
  * This method gets all the customers that have performed transactions on your platform with Paystack
  * @returns array
  */
@@ -232,32 +217,6 @@ Paystack::getAllTransactions();
  * @returns string
  */
 Paystack::genTranxRef();
-
-/**
-* This method creates a subaccount to be used for split payments 
-* @return array
-*/
-Paystack::createSubAccount();
-
-
-/**
-* This method fetches the details of a subaccount  
-* @return array
-*/
-Paystack::fetchSubAccount();
-
-
-/**
-* This method lists the subaccounts associated with your paystack account 
-* @return array
-*/
-Paystack::listSubAccounts();
-
-/**
-* This method Updates a subaccount to be used for split payments 
-* @return array
-*/
-Paystack::updateSubAccount();
 ```
 
 A sample form will look like so:
@@ -276,7 +235,6 @@ A sample form will look like so:
             <input type="hidden" name="orderID" value="345">
             <input type="hidden" name="amount" value="800"> {{-- required in kobo --}}
             <input type="hidden" name="quantity" value="3">
-            <input type="hidden" name="metadata" value="{{ json_encode($array = ['key_name' => 'value',]) }}" > {{-- For other necessary things you want to add to your payload. it is optional though --}}
             <input type="hidden" name="reference" value="{{ Paystack::genTranxRef() }}"> {{-- required --}}
             <input type="hidden" name="key" value="{{ config('paystack.secretKey') }}"> {{-- required --}}
             {{ csrf_field() }} {{-- works only when using laravel 5.1, 5.2 --}}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
    "require": {
     "php": "^5.4.0|^7.0",
     "illuminate/support": "5.*",
-    "guzzlehttp/guzzle": "5.*|6.*"
+    "guzzlehttp/guzzle": "5.*|6.*",
+     "ext-json": "*"
    },
    "require-dev": {
         "phpunit/phpunit" : "4.*",

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -230,8 +230,9 @@ class Paystack
 
         $result = $this->getResponse()['message'];
 
-        switch ($result) {
-            case self::VS:
+        //converting the string to lower case so as not to have issue
+        switch (strtolower($result)) {
+            case strtolower(self::VS):
                 $validate = true;
                 break;
             default:
@@ -246,6 +247,7 @@ class Paystack
      * Hit Paystack Gateway to Verify that the transaction is valid.
      *
      * @param string|null $trxref
+     * @throws PaymentVerificationFailedException
      */
     private function verifyTransactionAtGateway($trxref = null)
     {
@@ -253,6 +255,8 @@ class Paystack
         //then we will make use of it else we check the request query
         //for a parameter of 'trxref'
         $transactionRef = $trxref ?: request()->query('trxref');
+
+        if(!$transactionRef) throw new PaymentVerificationFailedException("Payment reference not provided");
 
         $relativeUrl = "/transaction/verify/{$transactionRef}";
 

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -12,6 +12,7 @@
 namespace Unicodeveloper\Paystack;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Config;
 use Unicodeveloper\Paystack\Exceptions\IsNullException;
 use Unicodeveloper\Paystack\Exceptions\PaymentVerificationFailedException;
@@ -226,21 +227,25 @@ class Paystack
      */
     public function isTransactionVerificationValid($transactionReferenceKey = null)
     {
-        $this->verifyTransactionAtGateway($transactionReferenceKey);
+        try {
+            $this->verifyTransactionAtGateway($transactionReferenceKey);
 
-        $result = $this->getResponse()['message'];
+            $result = $this->getResponse()['message'];
 
-        //converting the string to lower case so as not to have issue
-        switch (strtolower($result)) {
-            case strtolower(self::VS):
-                $validate = true;
-                break;
-            default:
-                $validate = false;
-                break;
+            //converting the string to lower case so as not to have issue
+            switch (strtolower($result)) {
+                case strtolower(self::VS):
+                    $validate = true;
+                    break;
+                default:
+                    $validate = false;
+                    break;
+            }
+
+            return $validate;
+        }catch (RequestException $exception){
+            return false;
         }
-
-        return $validate;
     }
 
     /**
@@ -261,6 +266,7 @@ class Paystack
         $relativeUrl = "/transaction/verify/{$transactionRef}";
 
         $this->response = $this->client->get($this->baseUrl . $relativeUrl, []);
+
     }
 
     /**

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -207,12 +207,13 @@ class Paystack
 
     /**
      * Get Payment details if the transaction was verified successfully
+     * @param string|null $transactionReferenceKey
      * @return array
      * @throws PaymentVerificationFailedException
      */
-    public function getPaymentData()
+    public function getPaymentData($transactionReferenceKey = null)
     {
-        if ($this->isTransactionVerificationValid()) {
+        if ($this->isTransactionVerificationValid($transactionReferenceKey)) {
             return $this->getResponse();
         } else {
             throw new PaymentVerificationFailedException("Invalid Transaction Reference");


### PR DESCRIPTION
The parameter allows the user (developer) to be able to parse transaction key from the source code without having to make a request.
This is useful in cases where the developer is trying to get the reference not because PayStack redirects the user after payment to the webhook/callback route but through other methods.