### PR TITLE
Adds Laravel 6.* Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/unicodeveloper/laravel-paystack.svg?style=flat-square)](https://scrutinizer-ci.com/g/unicodeveloper/laravel-paystack)
 [![Total Downloads](https://img.shields.io/packagist/dt/unicodeveloper/laravel-paystack.svg?style=flat-square)](https://packagist.org/packages/unicodeveloper/laravel-paystack)
 
-> A Laravel 5 Package for working with Paystack seamlessly
+> A Laravel Package for working with Paystack seamlessly
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unicodeveloper/laravel-paystack",
-    "description": "A Laravel 5 Package for Paystack",
-    "keywords": ["php","github", "laravel","Open Source","payments", "subscription", "paystack", "paystack.co","laravel 5"],
+    "description": "A Laravel Package for Paystack",
+    "keywords": ["php","github", "laravel","Open Source","payments", "subscription", "paystack", "paystack.co","laravel 5", "laravel 6"],
     "license": "MIT",
     "authors": [
       {
@@ -16,7 +16,7 @@
    "minimum-stability": "stable",
    "require": {
     "php": "^5.4.0|^7.0",
-    "illuminate/support": "5.*",
+    "illuminate/support": "5.*|6.*",
     "guzzlehttp/guzzle": "5.*|6.*"
    },
    "require-dev": {


### PR DESCRIPTION
This adds compatibility with Laravel 6.* and should close #82 and #80 

From the unit tests and a cursory look at the source files, all should go fine (hopefully), and I also tested by installing it as a private git package via composer using the answer here: https://stackoverflow.com/questions/12954051/use-php-composer-to-clone-git-repo#answer-27423768