### PR TITLE
Modified makePaymentRequest to accept multiple metadata as different inputs

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -134,7 +134,7 @@ class Paystack
                 *                                  ]
                 */            
                 // 'metadata' => request()->metadata
-                'metadata' => json_encode(request()->custom_metadata), // To accept metadata as individual inputs
+                'metadata' => json_encode(request()->custom_metadata) // To accept metadata as individual inputs
             ];
 
             // Remove the fields which were not sent (value would be null)

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -132,8 +132,9 @@ class Paystack
                 *                                                        ]
                 *                                        
                 *                                  ]
-                */
-                'metadata' => request()->metadata
+                */            
+                // 'metadata' => request()->metadata
+                'metadata' => json_encode(request()->custom_metadata), // To accept metadata as individual inputs
             ];
 
             // Remove the fields which were not sent (value would be null)


### PR DESCRIPTION
I wanted to populate the metadata input dynamically with more than one data using ajax and input id.  I noticed the input below would be easier to accept multiple input.

`<input type="hidden" id="meta..." name="custom_metadata[key]" value="value">`

instead of this:

`<input type="hidden" name="metadata" value="{{ json_encode($array = ['key_name' => 'value',]) }}" >`

For example:
```
<input type="hidden" id="meta..." name="custom_metadata[key1]" value="value1">
<input type="hidden" id="meta..." name="custom_metadata[key2]" value="value2">
```

Would be passed to PHP as:
array:2 [▼
  "key1" => "value1"
  "key2" => "value2"
]

and when encoded as json, would be:
"{"key1":"value1","key2":"value2"}"

achieving the same thing.