### PR TITLE
Added exception handling for expired code

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,11 @@ class PaymentController extends Controller
      */
     public function redirectToGateway()
     {
-        return Paystack::getAuthorizationUrl()->redirectNow();
+        try{
+            return Paystack::getAuthorizationUrl()->redirectNow();
+        }catch(\Exception $e) {
+            return Redirect::back()->withMessage(['msg'=>'The paystack token has expired. Please refresh the page and try again.', 'type'=>'error']);
+        }        
     }
 
     /**


### PR DESCRIPTION
Hi,

I got problem when reference code was expired if user go to paystack payment page and click browser back button to retry payment. So I added the exception handler for that error in paymentcontroller sample code. It will be helpful for developers to avoid that exception