### PR TITLE
Set default value for quantity field

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -113,7 +113,7 @@ class Paystack
     {
         if ( $data == null ) {
 
-            $quantity = intval(request()->quantity ? request()->quantity : 1);
+            $quantity = intval(request()->quantity ?? 1);
 
             $data = [
                 "amount" => intval(request()->amount) * $quantity,

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -113,7 +113,7 @@ class Paystack
     {
         if ( $data == null ) {
 
-            $quantity = intval(request()->quantity);
+            $quantity = intval(request()->quantity ? request()->quantity : 1);
 
             $data = [
                 "amount" => intval(request()->amount) * $quantity,


### PR DESCRIPTION
Greetings,
I encountered a 400 bad request as Paystack's response whenever I tried initialising a transaction. I discovered that not setting a quantity field in the request object would coerce the amount to zero, based on value returned from the **intval** function.
I figured it could be defaulted to the value, 1.