### PR TITLE
getAuthorizationUrl() to accept a data parameter

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -181,9 +181,9 @@ class Paystack
      * Get the authorization url from the callback response
      * @return Paystack
      */
-    public function getAuthorizationUrl()
+    public function getAuthorizationUrl($data = null)
     {
-        $this->makePaymentRequest();
+        $this->makePaymentRequest($data);
 
         $this->url = $this->getResponse()['data']['authorization_url'];
 


### PR DESCRIPTION
Allow getAuthorizationUrl() method to accept a data parameter for situations where you don't want to use data from the request.