### PR TITLE
Pass $transaction_id to verify transaction

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -86,7 +86,7 @@ class Paystack
      */
     private function setRequestOptions()
     {
-        $authBearer = 'Bearer '. $this->secretKey;
+        $authBearer = 'Bearer ' . $this->secretKey;
 
         $this->client = new Client(
             [
@@ -101,7 +101,7 @@ class Paystack
     }
 
 
-     /**
+    /**
 
      * Initiate a payment request to Paystack
      * Included the option to pass the payload to this method for situations
@@ -111,7 +111,7 @@ class Paystack
 
     public function makePaymentRequest($data = null)
     {
-        if ( $data == null ) {
+        if ($data == null) {
 
             $quantity = intval(request()->quantity ?? 1);
 
@@ -214,7 +214,7 @@ class Paystack
         return $this;
     }
 
-     /**
+    /**
      * Get the authorization callback response
      * In situations where Laravel serves as an backend for a detached UI, the api cannot redirect
      * and might need to take different actions based on the success or not of the transaction
@@ -232,9 +232,9 @@ class Paystack
     /**
      * Hit Paystack Gateway to Verify that the transaction is valid
      */
-    private function verifyTransactionAtGateway()
+    private function verifyTransactionAtGateway($transaction_id = null)
     {
-        $transactionRef = request()->query('trxref');
+        $transactionRef = $transaction_id ?? request()->query('trxref');
 
         $relativeUrl = "/transaction/verify/{$transactionRef}";
 
@@ -245,9 +245,9 @@ class Paystack
      * True or false condition whether the transaction is verified
      * @return boolean
      */
-    public function isTransactionVerificationValid()
+    public function isTransactionVerificationValid($transaction_id = null)
     {
-        $this->verifyTransactionAtGateway();
+        $this->verifyTransactionAtGateway($transaction_id);
 
         $result = $this->getResponse()['message'];
 
@@ -375,7 +375,6 @@ class Paystack
         $this->setRequestOptions();
 
         return $this->setHttpResponse("/plan", 'POST', $data)->getResponse();
-
     }
 
     /**
@@ -436,7 +435,7 @@ class Paystack
     public function fetchCustomer($customer_id)
     {
         $this->setRequestOptions();
-        return $this->setHttpResponse('/customer/'. $customer_id, 'GET', [])->getResponse();
+        return $this->setHttpResponse('/customer/' . $customer_id, 'GET', [])->getResponse();
     }
 
     /**
@@ -456,7 +455,7 @@ class Paystack
         ];
 
         $this->setRequestOptions();
-        return $this->setHttpResponse('/customer/'. $customer_id, 'PUT', $data)->getResponse();
+        return $this->setHttpResponse('/customer/' . $customer_id, 'PUT', $data)->getResponse();
     }
 
     /**
@@ -566,7 +565,7 @@ class Paystack
     public function fetchSubscription($subscription_id)
     {
         $this->setRequestOptions();
-        return $this->setHttpResponse('/subscription/'.$subscription_id, 'GET', [])->getResponse();
+        return $this->setHttpResponse('/subscription/' . $subscription_id, 'GET', [])->getResponse();
     }
 
     /**
@@ -602,7 +601,7 @@ class Paystack
     public function fetchPage($page_id)
     {
         $this->setRequestOptions();
-        return $this->setHttpResponse('/page/'.$page_id, 'GET', [])->getResponse();
+        return $this->setHttpResponse('/page/' . $page_id, 'GET', [])->getResponse();
     }
 
     /**
@@ -619,16 +618,17 @@ class Paystack
         ];
 
         $this->setRequestOptions();
-        return $this->setHttpResponse('/page/'.$page_id, 'PUT', $data)->getResponse();
+        return $this->setHttpResponse('/page/' . $page_id, 'PUT', $data)->getResponse();
     }
 
-     /**
+    /**
      * Creates a subaccount to be used for split payments . Required    params are business_name , settlement_bank , account_number ,   percentage_charge
      *
      * @return array
      */
 
-    public function createSubAccount(){
+    public function createSubAccount()
+    {
         $data = [
             "business_name" => request()->business_name,
             "settlement_bank" => request()->settlement_bank,
@@ -643,31 +643,30 @@ class Paystack
 
         $this->setRequestOptions();
         return $this->setHttpResponse('/subaccount', 'POST', array_filter($data))->getResponse();
-
     }
 
-     /**
+    /**
      * Fetches details of a subaccount
      * @param subaccount code
      * @return array
      */
-    public function fetchSubAccount($subaccount_code){
+    public function fetchSubAccount($subaccount_code)
+    {
 
         $this->setRequestOptions();
-        return $this->setHttpResponse("/subaccount/{$subaccount_code}","GET",[])->getResponse();
-
+        return $this->setHttpResponse("/subaccount/{$subaccount_code}", "GET", [])->getResponse();
     }
 
-     /**
+    /**
      * Lists all the subaccounts associated with the account
      * @param $per_page - Specifies how many records to retrieve per page , $page - SPecifies exactly what page to retrieve
      * @return array
      */
-    public function listSubAccounts($per_page,$page){
+    public function listSubAccounts($per_page, $page)
+    {
 
         $this->setRequestOptions();
-        return $this->setHttpResponse("/subaccount/?perPage=".(int) $per_page."&page=".(int) $page,"GET")->getResponse();
-
+        return $this->setHttpResponse("/subaccount/?perPage=" . (int) $per_page . "&page=" . (int) $page, "GET")->getResponse();
     }
 
 
@@ -677,7 +676,8 @@ class Paystack
      * @return array
      */
 
-    public function updateSubAccount($subaccount_code){
+    public function updateSubAccount($subaccount_code)
+    {
         $data = [
             "business_name" => request()->business_name,
             "settlement_bank" => request()->settlement_bank,
@@ -693,6 +693,5 @@ class Paystack
 
         $this->setRequestOptions();
         return $this->setHttpResponse("/subaccount/{$subaccount_code}", "PUT", array_filter($data))->getResponse();
-
     }
 }


### PR DESCRIPTION
Some transaction IDs requiring verification might be coming from a database or somewhere outside the **request()** object.
Hence, they should be able to pass those IDs into the **verifyTransactionAtGateway()** method as **$transaction_id**.
`Example`
`
$paystack->verifyTransactionAtGateway("trx_39403389239");

`