### PR TITLE
allowed the Paystack::createCustomer() method to accept a data parameter

### DIFF
--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":[],"times":{"Unicodeveloper\\Paystack\\Test\\HelpersTest::it_returns_instance_of_paystack":0.213,"Unicodeveloper\\Paystack\\Test\\PaystackTest::testAllCustomersAreReturned":0.089,"Unicodeveloper\\Paystack\\Test\\PaystackTest::testAllTransactionsAreReturned":0.001,"Unicodeveloper\\Paystack\\Test\\PaystackTest::testAllPlansAreReturned":0.001}}

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -412,17 +412,20 @@ class Paystack
     /**
      * Create a customer
      */
-    public function createCustomer()
+    public function createCustomer($data = null)
     {
-        $data = [
-            "email" => request()->email,
-            "first_name" => request()->fname,
-            "last_name" => request()->lname,
-            "phone" => request()->phone,
-            "metadata" => request()->additional_info /* key => value pairs array */
+        if ($data == null) {
 
-        ];
+            $data = [
+                "email" => request()->email,
+                "first_name" => request()->fname,
+                "last_name" => request()->lname,
+                "phone" => request()->phone,
+                "metadata" => request()->additional_info /* key => value pairs array */
 
+            ];
+        }
+        
         $this->setRequestOptions();
         return $this->setHttpResponse('/customer', 'POST', $data)->getResponse();
     }


### PR DESCRIPTION
This is needful because a customer sometimes are not created from the request data directly, so it is important if the data can be passed manually but it doesn't exist, it will fallback to the to the previous implementation  