### PR TITLE
feat: Update getPaymentData method to accept a reference parameter

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -272,9 +272,9 @@ class Paystack
      * @return json
      * @throws PaymentVerificationFailedException
      */
-    public function getPaymentData()
+    public function getPaymentData($reference)
     {
-        if ($this->isTransactionVerificationValid()) {
+        if ($this->isTransactionVerificationValid($reference)) {
             return $this->getResponse();
         } else {
             throw new PaymentVerificationFailedException("Invalid Transaction Reference");


### PR DESCRIPTION
This is to handle

 **GuzzleHttp\Exception\ClientException Client error: GET https://api.paystack.co/transaction/verify/ resulted in a 400 Bad Request response: { "status": false, "message": "Transaction ID should be numeric." }** 
 
 error that people keep on getting when using this with laravel.