### PR TITLE
Refactor Paystack Configuration to Use env() for Environment Variables

### DIFF
--- a/resources/config/paystack.php
+++ b/resources/config/paystack.php
@@ -15,24 +15,24 @@ return [
      * Public Key From Paystack Dashboard
      *
      */
-    'publicKey' => getenv('PAYSTACK_PUBLIC_KEY'),
+    'publicKey' => env('PAYSTACK_PUBLIC_KEY'),
 
     /**
      * Secret Key From Paystack Dashboard
      *
      */
-    'secretKey' => getenv('PAYSTACK_SECRET_KEY'),
+    'secretKey' => env('PAYSTACK_SECRET_KEY'),
 
     /**
      * Paystack Payment URL
      *
      */
-    'paymentUrl' => getenv('PAYSTACK_PAYMENT_URL'),
+    'paymentUrl' => env('PAYSTACK_PAYMENT_URL'),
 
     /**
      * Optional email address of the merchant
      *
      */
-    'merchantEmail' => getenv('MERCHANT_EMAIL'),
+    'merchantEmail' => env('MERCHANT_EMAIL'),
 
 ];


### PR DESCRIPTION
This pull request refactors the Paystack Laravel package configuration to use the env() function instead of getenv() for retrieving environment variables. This change was made to resolve an issue encountered in the production environment.

Changes:

    Replaced getenv calls with env() in the paystack.php configuration file to fetch environment variables.

Reason for the Change:

    Issue with getenv() in Production: The original implementation using getenv() was not loading environment variables correctly in the production environment. This caused issues such as the error "URI must be a string or UriInterface," as the required configuration values were not properly retrieved.
    env() for Consistency: Using env() aligns with Laravel’s recommended practices for accessing environment variables. It ensures that values are correctly loaded from the .env file and properly utilized in the application.
    Configuration Caching: The env() function allows Laravel to cache configuration settings, improving performance and ensuring that environment-specific values are consistently available across different environments.

This refactor addresses the issue of environment variable loading and ensures that the Paystack configuration works reliably in both development and production environments.